### PR TITLE
support 0.6 (means dropping 0.4)

### DIFF
--- a/lib/zsock.js
+++ b/lib/zsock.js
@@ -1,7 +1,7 @@
 // Copyright 2011 Mark Cavage <mcavage@gmail.com> All rights reserved.
 var Socket = require('net').Socket;
 
-var bindings = require('../build/default/zsock_bindings');
+var bindings = require('../build/Release/zsock_bindings');
 
 module.exports = {
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zsock",
   "description": "A small library for opening Unix Domain Sockets in Solaris Zones.",
-  "version": "1.0.5",
+  "version": "1.1.0",
   "repository": {
     "type": "git",
     "url": "git://github.com/mcavage/node-zsock.git"
@@ -9,7 +9,8 @@
   "author": "Mark Cavage <mcavage@gmail.com> (http://www.joyent.com)",
   "main": "lib/zsock.js",
   "scripts": {
-    "preinstall": "node-waf configure build"
+    "preinstall": "node-waf configure build",
+    "test": "TEST_ZONE=`zoneadm list | grep -v global | head -1` ./node_modules/.bin/nodeunit tst/*.test.js"
   },
   "devDependencies": {
     "jshint": ">=0.1.9",
@@ -17,6 +18,6 @@
     "node-uuid": "1.1.0"
   },
   "engines": {
-    "node": ">=0.4"
+    "node": ">=0.6"
   }
 }

--- a/src/zsock.cc
+++ b/src/zsock.cc
@@ -423,13 +423,13 @@ class eio_baton_t {
   eio_baton_t &operator=(const eio_baton_t &);
 };
 
-static int EIO_ZSocket(eio_req *req) {
+static void EIO_ZSocket(eio_req *req) {
   eio_baton_t *baton = static_cast<eio_baton_t *>(req->data);
 
   zoneid_t zoneid = getzoneidbyname(baton->_zone);
   if (zoneid < 0) {
     baton->setErrno("getzoneidbyname", errno);
-    return 0;
+    return;
   }
   int sock_fd = -1;
   int attempts = 1;
@@ -439,17 +439,17 @@ static int EIO_ZSocket(eio_req *req) {
 	} while (attempts++ < 3 && sock_fd < 0);
   if (sock_fd < 0) {
     baton->setErrno("zsocket", errno);
-    return 0;
+    return;
   }
 
   if (listen(sock_fd, baton->_backlog) != 0) {
     baton->setErrno("listen", errno);
-    return 0;
+    return;
   }
 
   baton->_fd = sock_fd;
 
-  return 0;
+  return;
 }
 
 static int EIO_After(eio_req *req) {

--- a/tst/zsock.test.js
+++ b/tst/zsock.test.js
@@ -8,7 +8,7 @@ var zsock = require('../lib/zsock');
 /**
  * In order to run these tests, you must:
  * 1) Be root
- * 2) have a zone called foo
+ * 2) have a zone called foo (or set TEST_ZONE to the zone name)
  * 3) Have configure your zones to live under /zones
  *
  * Basically, it's probably easier if you just trust me
@@ -17,7 +17,7 @@ var zsock = require('../lib/zsock');
 module.exports = testCase({
 
   setUp: function(callback) {
-    this.zone = 'foo'; // Replace with whatever zone you have!
+    this.zone = process.env.TEST_ZONE || 'foo';
     this.socketPath = '/tmp/.' + uuid();
     callback();
   },
@@ -88,10 +88,11 @@ module.exports = testCase({
 
   success: function(test) {
     var self = this;
-    test.expect(2);
+    test.expect(3);
+    test.equal(process.getuid(), 0, "must be root to run this test");
 
     var _cb = function(err, fd) {
-      test.ok(!err);
+      test.ok(!err, err + " (must have zone named 'foo' or set TEST_ZONE envvar)");
       test.ok(fd);
       test.done();
     };


### PR DESCRIPTION
Perhaps this is incomplete. For example, I haven't looked at `listenFD` usage yet. Just made it build and pass testsuite.
